### PR TITLE
Fix Offline-mode breaking everything

### DIFF
--- a/EXILED/Exiled.API/Enums/AuthenticationType.cs
+++ b/EXILED/Exiled.API/Enums/AuthenticationType.cs
@@ -42,5 +42,10 @@ namespace Exiled.API.Enums
         /// Indicates that the player has been authenticated as DedicatedServer.
         /// </summary>
         DedicatedServer,
+
+        /// <summary>
+        /// Indicates that the player has been authenticated during Offline mode.
+        /// </summary>
+        Offline,
     }
 }

--- a/EXILED/Exiled.API/Extensions/StringExtensions.cs
+++ b/EXILED/Exiled.API/Extensions/StringExtensions.cs
@@ -161,7 +161,11 @@ namespace Exiled.API.Extensions
         /// </summary>
         /// <param name="userId">The user id.</param>
         /// <returns>Returns the raw user id.</returns>
-        public static string GetRawUserId(this string userId) => userId.Substring(0, userId.LastIndexOf('@'));
+        public static string GetRawUserId(this string userId)
+        {
+            int index = userId.IndexOf('@');
+            return index == -1 ? userId : userId.Substring(0, index);
+        }
 
         /// <summary>
         /// Gets a SHA256 hash of a player's user id without the authentication.

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -282,6 +282,7 @@ namespace Exiled.API.Features
                     "northwood" => AuthenticationType.Northwood,
                     "localhost" => AuthenticationType.LocalHost,
                     "ID_Dedicated" => AuthenticationType.DedicatedServer,
+                    "offline" => AuthenticationType.Offline,
                     _ => AuthenticationType.Unknown,
                 };
             }

--- a/EXILED/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -7,16 +7,20 @@
 
 namespace Exiled.Events.Patches.Events.Player
 {
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
     using System;
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
 
     using API.Features;
+    using API.Features.Pools;
     using CentralAuth;
     using Exiled.API.Extensions;
     using Exiled.Events.EventArgs.Player;
-
     using HarmonyLib;
 
-#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+    using static HarmonyLib.AccessTools;
 
     /// <summary>
     /// Patches <see cref="PlayerAuthenticationManager.FinalizeAuthentication" />.
@@ -25,12 +29,16 @@ namespace Exiled.Events.Patches.Events.Player
     [HarmonyPatch(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager.FinalizeAuthentication))]
     internal static class Verified
     {
-        private static void Postfix(PlayerAuthenticationManager __instance)
+        /// <summary>
+        ///     Called after the player has been verified.
+        /// </summary>
+        /// <param name="hub">The player's hub.</param>
+        internal static void PlayerVerified(ReferenceHub hub)
         {
-            if (!Player.UnverifiedPlayers.TryGetValue(__instance._hub.gameObject, out Player player))
-                Joined.CallEvent(__instance._hub, out player);
+            if (!Player.UnverifiedPlayers.TryGetValue(hub.gameObject, out Player player))
+                Joined.CallEvent(hub, out player);
 
-            Player.Dictionary.Add(__instance._hub.gameObject, player);
+            Player.Dictionary.Add(hub.gameObject, player);
 
             player.IsVerified = true;
             player.RawUserId = player.UserId.GetRawUserId();
@@ -38,6 +46,42 @@ namespace Exiled.Events.Patches.Events.Player
             Log.SendRaw($"Player {player.Nickname} ({player.UserId}) ({player.Id}) connected with the IP: {player.IPAddress}", ConsoleColor.Green);
 
             Handlers.Player.OnVerified(new VerifiedEventArgs(player));
+        }
+
+        private static void Postfix(PlayerAuthenticationManager __instance)
+        {
+            PlayerVerified(__instance._hub);
+        }
+    }
+
+    /// <summary>
+    ///     Patches <see cref="NicknameSync.UserCode_CmdSetNick__String" />.
+    ///     Adds the <see cref="Handlers.Player.Verified" /> event during offline mode.
+    /// </summary>
+    [HarmonyPatch(typeof(NicknameSync), nameof(NicknameSync.UserCode_CmdSetNick__String))]
+    internal static class VerifiedOfflineMode
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            const int offset = 1;
+            int index = newInstructions.FindIndex(x => x.opcode == OpCodes.Callvirt && x.OperandIs(Method(typeof(CharacterClassManager), nameof(CharacterClassManager.SyncServerCmdBinding)))) + offset;
+
+            // Verified.PlayerVerified(this._hub);
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Ldfld, Field(typeof(NicknameSync), nameof(NicknameSync._hub))),
+                    new CodeInstruction(OpCodes.Call, Method(typeof(Verified), nameof(Verified.PlayerVerified))),
+                });
+
+            for (int i = 0; i < newInstructions.Count; i++)
+                yield return newInstructions[i];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
         }
     }
 }

--- a/EXILED/Exiled.Events/Patches/Generic/OfflineModePlayerIds.cs
+++ b/EXILED/Exiled.Events/Patches/Generic/OfflineModePlayerIds.cs
@@ -1,0 +1,133 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="OfflineModePlayerIds.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Generic
+{
+#pragma warning disable SA1402 // File may only contain a single type
+    using System.Collections.Generic;
+    using System.Reflection.Emit;
+
+    using API.Features.Pools;
+    using CentralAuth;
+    using HarmonyLib;
+    using PluginAPI.Core.Interfaces;
+    using PluginAPI.Events;
+
+    using static HarmonyLib.AccessTools;
+
+    /// <summary>
+    ///     Patches <see cref="PlayerAuthenticationManager.Start"/> to add the player's UserId to the <see cref="PluginAPI.Core.Player.PlayersUserIds"/> dictionary.
+    /// </summary>
+    [HarmonyPatch(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager.Start))]
+    internal static class OfflineModePlayerIds
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            Label skipLabel = generator.DefineLabel();
+
+            const int offset = 1;
+            int index = newInstructions.FindLastIndex(instruction => instruction.opcode == OpCodes.Call && instruction.OperandIs(PropertySetter(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager.UserId)))) + offset;
+
+            // if (!Player.PlayersUserIds.ContainsKey(this.UserId))
+            //       Player.PlayersUserIds.Add(this.UserId, this._hub);
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new(OpCodes.Ldsfld, Field(typeof(PluginAPI.Core.Player), nameof(PluginAPI.Core.Player.PlayersUserIds))),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Call, PropertyGetter(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager.UserId))),
+                    new(OpCodes.Callvirt, Method(typeof(Dictionary<string, IGameComponent>), nameof(Dictionary<string, IGameComponent>.ContainsKey))),
+                    new(OpCodes.Brtrue_S, skipLabel),
+                    new(OpCodes.Ldsfld, Field(typeof(PluginAPI.Core.Player), nameof(PluginAPI.Core.Player.PlayersUserIds))),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Call, PropertyGetter(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager.UserId))),
+                    new(OpCodes.Ldarg_0),
+                    new(OpCodes.Ldfld, Field(typeof(PlayerAuthenticationManager), nameof(PlayerAuthenticationManager._hub))),
+                    new(OpCodes.Callvirt, Method(typeof(Dictionary<string, IGameComponent>), nameof(Dictionary<string, IGameComponent>.Add))),
+                    new CodeInstruction(OpCodes.Nop).WithLabels(skipLabel),
+                });
+
+            for (int i = 0; i < newInstructions.Count; i++)
+            {
+                yield return newInstructions[i];
+            }
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    ///     Patches <see cref="ReferenceHub.Start"/> to prevent it from executing the <see cref="PluginAPI.Events.PlayerLeftEvent"/> event when the server is in offline mode.
+    /// </summary>
+    [HarmonyPatch(typeof(ReferenceHub), nameof(ReferenceHub.Start))]
+    internal static class OfflineModeReferenceHub
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            const int offset = 1;
+            int index = newInstructions.FindIndex(x => x.opcode == OpCodes.Callvirt) + offset;
+
+            Label returnLabel = generator.DefineLabel();
+
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Br_S, returnLabel),
+                });
+
+            newInstructions[newInstructions.Count - 1].WithLabels(returnLabel);
+
+            for (int i = 0; i < newInstructions.Count; i++)
+            {
+                yield return newInstructions[i];
+            }
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+    }
+
+    /// <summary>
+    ///     Patches <see cref="NicknameSync.UserCode_CmdSetNick__String"/> to execute the <see cref="PlayerJoinedEvent"/> event when the server is in offline mode.
+    /// </summary>
+    [HarmonyPatch(typeof(NicknameSync), nameof(NicknameSync.UserCode_CmdSetNick__String))]
+    internal static class OfflineModeJoin
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> newInstructions = ListPool<CodeInstruction>.Pool.Get(instructions);
+
+            const int offset = 1;
+            int index = newInstructions.FindIndex(x => x.opcode == OpCodes.Callvirt && x.OperandIs(Method(typeof(CharacterClassManager), nameof(CharacterClassManager.SyncServerCmdBinding)))) + offset;
+
+            // EventManager.ExecuteEvent(new PlayerJoinedEvent(this._hub));
+            newInstructions.InsertRange(
+                index,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Ldfld, Field(typeof(NicknameSync), nameof(NicknameSync._hub))),
+                    new CodeInstruction(OpCodes.Call, Method(typeof(OfflineModeJoin), nameof(ExecuteNwEvent))),
+                });
+
+            for (int i = 0; i < newInstructions.Count; i++)
+                yield return newInstructions[i];
+
+            ListPool<CodeInstruction>.Pool.Return(newInstructions);
+        }
+
+        private static void ExecuteNwEvent(ReferenceHub hub)
+        {
+            EventManager.ExecuteEvent(new PlayerJoinedEvent(hub));
+        }
+    }
+}


### PR DESCRIPTION
This PR does the following:

- Executes the `Verified` event in offline-mode
- Executes PluginApi's `PlayerJoinedEvent` in offline-mode
- Adds the Player's UserId to the base-game `Player.PlayersUserIds` dictionary in offline-mode
- Prevents PluginApi's `PlayerLeftEvent` from getting executed within the ReferenceHubs' Start method. Not sure why that is even a thing in the first place as it only causes issues.


This fixes bugs such as base-game roles spawning with no items during offline-mode when using EXILED
and most (if not all) events not being called at all in offline-mode



Only thing I might want to change is how I handle `ReferenceHub.Start` as currently I just skip to the end after the `callvirt` instruction. Instead I could remove the `ldarg.0`, `newobj`, `call`, `pop` instructions (essentially remove the call to `EventManager.ExecuteEvent(new PlayerLeftEvent(this))`)

  


